### PR TITLE
AB#4150 Fix: publish the 'local' chart artifact only for main/0.2/release builds

### DIFF
--- a/devops-build/azure-pipelines.yml
+++ b/devops-build/azure-pipelines.yml
@@ -195,9 +195,15 @@ stages:
               condition: and(succeeded(), eq(variables.isRelease, true))
 
           # Pipeline artifact retained for deploy-octo-mesh-core-services* —
-          # they read versioninfo.txt from this `local` artifact.
+          # they read versioninfo.txt from this `local` artifact. Restricted to
+          # the builds those deploy pipelines may consume (main / 0.2-* / r-tags):
+          # ADO resolves a non-triggering pipeline resource to the LATEST build
+          # with artifacts regardless of branch, so a PR or dev/* build that
+          # publishes `local` can be deployed verbatim (incident 2026-06-10:
+          # unmerged PR chart on test-2 + instancePrefix "merge" split-brain).
           - task: PowerShell@2
             displayName: 'Create version info file'
+            condition: and(succeeded(), or(eq(variables.isMain, true), eq(variables.isRelease, true), startsWith(variables['Build.SourceBranch'], 'refs/heads/0.2')))
             inputs:
               targetType: 'inline'
               script: |
@@ -205,5 +211,6 @@ stages:
                 Set-Content $(build.artifactstagingdirectory)/versioninfo.txt $(Build.BuildNumber)
           - task: PublishBuildArtifacts@1
             displayName: 'Publish Artifact: local'
+            condition: and(succeeded(), or(eq(variables.isMain, true), eq(variables.isRelease, true), startsWith(variables['Build.SourceBranch'], 'refs/heads/0.2')))
             inputs:
               ArtifactName: local


### PR DESCRIPTION
## Summary
- Adds the house `condition:` pattern (cf. the service repos' `build-and-push-docker-image.yml`) to the `Create version info file` + `Publish Artifact: local` steps: only `main`, `0.2*` branches and `r*` release tags publish the pipeline artifact.
- Chart-repo publishing (gh-pages dev/release channels) was already gated on `isMain`/`isRelease` — but the `local` **pipeline artifact** was published unconditionally, including PR-validation and `dev/*` builds.

## Why
`deploy-octo-mesh-core-services-test-2.yml` resolves its `helmCharts` resource to the **latest build with artifacts of any branch** when triggered by another pipeline. On 2026-06-10 that was PR #6's validation build: the unmerged chart was deployed to test-2 (deleting the identity DataProtection PVC prematurely) and `versioninfo.txt` derived `instancePrefix=merge`, splitting the core services from the adapters (`main`) on RabbitMQ — pipeline messaging was silently dead until the next main deploy.

## Azure DevOps Work Item
[AB#4150](https://dev.azure.com/meshmakers/c85af059-45e1-40ff-9229-52bc69642d53/_workitems/edit/4150)

## Test Plan
- [x] Conditions copied from the established service-repo pattern; `isMain`/`isRelease` variables already exist in this pipeline
- [ ] After merge: confirm the main build still publishes `local` (rolling deploy keeps working) and the next PR build does NOT

🤖 Generated with [Claude Code](https://claude.com/claude-code)